### PR TITLE
fix: 同一タスクの複数Period登録時のハイライト問題を修正

### DIFF
--- a/components/gantt/GanttChart.tsx
+++ b/components/gantt/GanttChart.tsx
@@ -37,7 +37,7 @@ export function GanttChart() {
 		period: { taskId: string; startDate: string; endDate: string } | null,
 	) => {
 		if (period) {
-			setSelectedPeriod(period);
+			setSelectedPeriod({ ...period, isNew: true });
 			setIsModalOpen(true);
 		}
 	};
@@ -53,6 +53,7 @@ export function GanttChart() {
 			taskId,
 			startDate: period.startDate,
 			endDate: period.endDate,
+			isNew: false,
 		});
 		setIsEditModalOpen(true);
 	};

--- a/components/gantt/TaskRow.tsx
+++ b/components/gantt/TaskRow.tsx
@@ -226,7 +226,7 @@ export function TaskRow({
 		}
 
 		// モーダルで選択された期間のハイライト（新規作成時のみ）
-		if (selectedPeriod && selectedPeriod.taskId === task.id && isAddModalOpen) {
+		if (selectedPeriod && selectedPeriod.taskId === task.id && isAddModalOpen && (selectedPeriod.isNew !== false)) {
 			const selectedStartDate = new Date(selectedPeriod.startDate);
 			const selectedEndDate = new Date(selectedPeriod.endDate);
 			const currentDate = dates[index];

--- a/lib/stores/gantt.store.ts
+++ b/lib/stores/gantt.store.ts
@@ -12,10 +12,11 @@ interface GanttStore {
 		taskId: string;
 		startDate: string;
 		endDate: string;
+		isNew?: boolean; // 新規作成かどうかを示すフラグ
 	} | null;
 	editingTaskId: string | null;
 	setSelectedPeriod: (
-		period: { taskId: string; startDate: string; endDate: string } | null,
+		period: { taskId: string; startDate: string; endDate: string; isNew?: boolean } | null,
 	) => void;
 	updateSelectedPeriod: (
 		startDate: string,

--- a/lib/types/gantt.ts
+++ b/lib/types/gantt.ts
@@ -25,5 +25,6 @@ export interface GanttState {
 		taskId: string;
 		startDate: string;
 		endDate: string;
+		isNew?: boolean;
 	} | null;
 }


### PR DESCRIPTION
Fixes #13

## 概要

同一タスクに複数のPeriod登録時に、既存のPeriodが新規選択期間としてハイライト表示される問題を修正しました。

## 変更内容

- `selectedPeriod`に`isNew`フラグを追加して新規作成と既存編集を区別
- `isDateInPreview`関数で新規作成時のみハイライト表示するよう修正
- 既存期間が新規選択範囲として誤ってハイライトされる問題を解決

## テスト方法

1. 任意のタスクにPeriodを登録
2. 同じタスクに別期間のPeriodを追加するため、ドラッグ&ドロップで新しい期間を選択
3. 新規選択期間のみがハイライトされ、既存期間はハイライトされないことを確認

Generated with [Claude Code](https://claude.ai/code)