### PR TITLE
feat: Period重複制御機能の実装

### DIFF
--- a/components/gantt/AddPeriodModal.tsx
+++ b/components/gantt/AddPeriodModal.tsx
@@ -77,8 +77,10 @@ export function AddPeriodModal({
 	startDate,
 	endDate,
 }: AddPeriodModalProps) {
-	const { tags, addPeriod, tasks, updateSelectedPeriod } = useGanttStore();
+	const { tags, addPeriod, tasks, updateSelectedPeriod, getDisabledDates } =
+		useGanttStore();
 	const task = tasks.find((t) => t.id === taskId);
+	const disabledDates = getDisabledDates(taskId);
 
 	const form = useForm<z.infer<typeof FormSchema>>({
 		resolver: zodResolver(FormSchema),
@@ -197,6 +199,9 @@ export function AddPeriodModal({
 															);
 														}}
 														captionLayout="dropdown"
+														disabled={disabledDates.map(
+															(dateStr) => new Date(dateStr),
+														)}
 													/>
 												</PopoverContent>
 											</Popover>
@@ -246,6 +251,9 @@ export function AddPeriodModal({
 															);
 														}}
 														captionLayout="dropdown"
+														disabled={disabledDates.map(
+															(dateStr) => new Date(dateStr),
+														)}
 													/>
 												</PopoverContent>
 											</Popover>

--- a/components/gantt/DateRange.tsx
+++ b/components/gantt/DateRange.tsx
@@ -143,6 +143,7 @@ export function DateRange({
 			if (hasOverlap(updatedPeriod, existingPeriods, period.id)) {
 				toast.error("選択した期間に既存のPeriodがあります", {
 					description: "別の期間を選択してください",
+					id: "period-edit-overlap-error",
 				});
 
 				// 元の位置に戻す

--- a/components/gantt/DateRange.tsx
+++ b/components/gantt/DateRange.tsx
@@ -1,4 +1,4 @@
-import { format } from "date-fns";
+import { format, parseISO } from "date-fns";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useGanttStore } from "@/lib/stores/gantt.store";
@@ -245,8 +245,8 @@ export function DateRange({
 	// selectedPeriodが変更されたときにtempOffsetとtempDurationを更新
 	useEffect(() => {
 		if (isSelectedAndModified && dates.length > 0) {
-			const newStartDate = new Date(selectedPeriod.startDate);
-			const newEndDate = new Date(selectedPeriod.endDate);
+			const newStartDate = parseISO(selectedPeriod.startDate);
+			const newEndDate = parseISO(selectedPeriod.endDate);
 
 			// 新しい開始位置を計算
 			const newStartIndex = findDateIndex(dates, newStartDate);

--- a/components/gantt/DateRange.tsx
+++ b/components/gantt/DateRange.tsx
@@ -1,7 +1,9 @@
 import { format } from "date-fns";
 import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
 import { useGanttStore } from "@/lib/stores/gantt.store";
 import type { Period } from "@/lib/types/gantt";
+import { hasOverlap } from "@/lib/utils/period-overlap";
 
 // 定数
 const DAY_WIDTH = 40; // pixels per day
@@ -31,6 +33,7 @@ interface DateRangeProps {
 	color: string;
 	dates: Date[];
 	taskId: string;
+	existingPeriods: Period[];
 	onEdit?: (period: Period, taskId: string) => void;
 }
 
@@ -41,6 +44,7 @@ export function DateRange({
 	color,
 	dates,
 	taskId,
+	existingPeriods,
 	onEdit,
 }: DateRangeProps) {
 	const { selectedPeriod } = useGanttStore();
@@ -129,12 +133,23 @@ export function DateRange({
 		const newEndDate = dates[tempOffset + tempDuration - 1];
 
 		if (newStartDate && newEndDate) {
-			// 既存期間データに更新された日付を含めて編集モーダルを開く
 			const updatedPeriod = {
 				...period,
 				startDate: format(newStartDate, "yyyy-MM-dd"),
 				endDate: format(newEndDate, "yyyy-MM-dd"),
 			};
+
+			// 重複チェック（現在編集中のPeriodは除外）
+			if (hasOverlap(updatedPeriod, existingPeriods, period.id)) {
+				toast.error("選択した期間に既存のPeriodがあります", {
+					description: "別の期間を選択してください",
+				});
+
+				// 元の位置に戻す
+				setTempOffset(startOffset);
+				setTempDuration(duration);
+				return;
+			}
 
 			// 編集のコールバックを呼び出してEditPeriodModalを開く
 			onEdit?.(updatedPeriod, taskId);
@@ -148,6 +163,9 @@ export function DateRange({
 		tempDuration,
 		dates,
 		period,
+		existingPeriods,
+		startOffset,
+		duration,
 		onEdit,
 		taskId,
 	]);

--- a/components/gantt/EditPeriodModal.tsx
+++ b/components/gantt/EditPeriodModal.tsx
@@ -75,9 +75,16 @@ export function EditPeriodModal({
 	onClose,
 	period,
 }: EditPeriodModalProps) {
-	const { tags, updatePeriod, deletePeriod, tasks, updateSelectedPeriod } =
-		useGanttStore();
+	const {
+		tags,
+		updatePeriod,
+		deletePeriod,
+		tasks,
+		updateSelectedPeriod,
+		getDisabledDates,
+	} = useGanttStore();
 	const task = tasks.find((t) => t.periods.some((p) => p.id === period?.id));
+	const disabledDates = task ? getDisabledDates(task.id, period?.id) : [];
 	const [deleteDialog, setDeleteDialog] = useState<{
 		isOpen: boolean;
 		periodId: string;
@@ -222,6 +229,9 @@ export function EditPeriodModal({
 																);
 															}}
 															captionLayout="dropdown"
+															disabled={disabledDates.map(
+																(dateStr) => new Date(dateStr),
+															)}
 														/>
 													</PopoverContent>
 												</Popover>
@@ -271,6 +281,9 @@ export function EditPeriodModal({
 																);
 															}}
 															captionLayout="dropdown"
+															disabled={disabledDates.map(
+																(dateStr) => new Date(dateStr),
+															)}
 														/>
 													</PopoverContent>
 												</Popover>

--- a/components/gantt/TaskRow.tsx
+++ b/components/gantt/TaskRow.tsx
@@ -349,6 +349,7 @@ export function TaskRow({
 						color={tag?.color || "#6B7280"}
 						dates={dates}
 						taskId={task.id}
+						existingPeriods={task.periods}
 						onEdit={onPeriodEdit}
 					/>
 				);

--- a/components/gantt/TaskRow.tsx
+++ b/components/gantt/TaskRow.tsx
@@ -109,33 +109,6 @@ export function TaskRow({
 		setDragEnd(index);
 	};
 
-	const handleMouseUp = () => {
-		if (isDragging && dragStart !== null && dragEnd !== null) {
-			const start = Math.min(dragStart, dragEnd);
-			const end = Math.max(dragStart, dragEnd);
-
-			const period = {
-				taskId: task.id,
-				startDate: format(dates[start], "yyyy-MM-dd"),
-				endDate: format(dates[end], "yyyy-MM-dd"),
-			};
-
-			// 重複チェック
-			if (hasOverlap(period, task.periods)) {
-				toast.error("選択した期間に既存のPeriodがあります", {
-					description: "別の期間を選択してください",
-				});
-			} else {
-				onPeriodSelect(period);
-			}
-		}
-
-		setIsDragging(false);
-		setDragStart(null);
-		setDragEnd(null);
-		stopAutoScroll();
-	};
-
 	// マウス位置ベースのスクロール判定
 	const handleMouseMove = useCallback(
 		(index: number, event: React.MouseEvent<HTMLDivElement>) => {
@@ -298,7 +271,6 @@ export function TaskRow({
 		<section
 			ref={gridRef}
 			className="relative h-16 select-none min-w-max"
-			onMouseUp={handleMouseUp}
 			aria-label="Period selection grid"
 		>
 			<div className="absolute inset-0 flex">
@@ -329,7 +301,6 @@ export function TaskRow({
 							aria-label={`Select ${dateString}`}
 							onMouseDown={() => handleMouseDown(index)}
 							onMouseEnter={(e) => handleMouseMove(index, e)}
-							onMouseUp={handleMouseUp}
 							onKeyDown={(e) => {
 								if (e.key === "Enter" || e.key === " ") {
 									const dateStr = format(dates[index], "yyyy-MM-dd");

--- a/components/gantt/TaskRow.tsx
+++ b/components/gantt/TaskRow.tsx
@@ -152,6 +152,7 @@ export function TaskRow({
 				if (hasOverlap(period, task.periods)) {
 					toast.error("選択した期間に既存のPeriodがあります", {
 						description: "別の期間を選択してください",
+						id: "period-overlap-error",
 					});
 				} else {
 					onPeriodSelect(period);
@@ -309,6 +310,7 @@ export function TaskRow({
 									if (isDateOccupied(dateStr, task.periods)) {
 										toast.error("この日付には既にPeriodが存在します", {
 											description: "別の日付を選択してください",
+											id: "date-occupied-error",
 										});
 									} else {
 										const period = {

--- a/lib/stores/gantt.store.ts
+++ b/lib/stores/gantt.store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import initialData from "@/lib/data/initial-data.json";
 import type { Period, Tag, Task } from "@/lib/types/gantt";
+import { getOccupiedDates } from "@/lib/utils/period-overlap";
 
 let taskCounter = 0;
 let periodCounter = 0;
@@ -42,6 +43,8 @@ interface GanttStore {
 	updateTask: (taskId: string, name: string) => void;
 	deleteTask: (taskId: string) => void;
 	setEditingTaskId: (taskId: string | null) => void;
+	// Calendar用のdisabled dates機能
+	getDisabledDates: (taskId: string, excludeId?: string) => string[];
 }
 
 export const useGanttStore = create<GanttStore>((set, get) => ({
@@ -138,5 +141,14 @@ export const useGanttStore = create<GanttStore>((set, get) => ({
 
 	setEditingTaskId: (taskId) => {
 		set({ editingTaskId: taskId });
+	},
+
+	// Calendar用のdisabled dates機能の実装
+	getDisabledDates: (taskId, excludeId) => {
+		const { tasks } = get();
+		const task = tasks.find((t) => t.id === taskId);
+		if (!task) return [];
+
+		return getOccupiedDates(task.periods, excludeId);
 	},
 }));

--- a/lib/utils/period-overlap.ts
+++ b/lib/utils/period-overlap.ts
@@ -1,3 +1,4 @@
+import { parseISO } from "date-fns";
 import type { Period } from "@/lib/types/gantt";
 
 /**
@@ -7,10 +8,10 @@ export function hasDateRangeOverlap(
 	range1: { startDate: string; endDate: string },
 	range2: { startDate: string; endDate: string },
 ): boolean {
-	const start1 = new Date(range1.startDate);
-	const end1 = new Date(range1.endDate);
-	const start2 = new Date(range2.startDate);
-	const end2 = new Date(range2.endDate);
+	const start1 = parseISO(range1.startDate);
+	const end1 = parseISO(range1.endDate);
+	const start2 = parseISO(range2.startDate);
+	const end2 = parseISO(range2.endDate);
 
 	// 重複の条件: range1の開始日がrange2の終了日以前 かつ range1の終了日がrange2の開始日以降
 	return start1 <= end2 && end1 >= start2;
@@ -43,11 +44,11 @@ export function isDateOccupied(
 		? existingPeriods.filter((p) => p.id !== excludeId)
 		: existingPeriods;
 
-	const targetDate = new Date(date);
+	const targetDate = parseISO(date);
 
 	return targetPeriods.some((period) => {
-		const startDate = new Date(period.startDate);
-		const endDate = new Date(period.endDate);
+		const startDate = parseISO(period.startDate);
+		const endDate = parseISO(period.endDate);
 		return targetDate >= startDate && targetDate <= endDate;
 	});
 }
@@ -66,8 +67,8 @@ export function getOccupiedDates(
 	const occupiedDates = new Set<string>();
 
 	targetPeriods.forEach((period) => {
-		const startDate = new Date(period.startDate);
-		const endDate = new Date(period.endDate);
+		const startDate = parseISO(period.startDate);
+		const endDate = parseISO(period.endDate);
 
 		// 期間内の全ての日付を追加
 		const currentDate = new Date(startDate);

--- a/lib/utils/period-overlap.ts
+++ b/lib/utils/period-overlap.ts
@@ -1,4 +1,4 @@
-import { parseISO } from "date-fns";
+import { isValid, parseISO } from "date-fns";
 import type { Period } from "@/lib/types/gantt";
 
 /**
@@ -12,6 +12,17 @@ export function hasDateRangeOverlap(
 	const end1 = parseISO(range1.endDate);
 	const start2 = parseISO(range2.startDate);
 	const end2 = parseISO(range2.endDate);
+
+	// 日付の有効性をチェック
+	if (
+		!isValid(start1) ||
+		!isValid(end1) ||
+		!isValid(start2) ||
+		!isValid(end2)
+	) {
+		console.warn("Invalid date string provided to hasDateRangeOverlap");
+		return false;
+	}
 
 	// 重複の条件: range1の開始日がrange2の終了日以前 かつ range1の終了日がrange2の開始日以降
 	return start1 <= end2 && end1 >= start2;
@@ -46,9 +57,22 @@ export function isDateOccupied(
 
 	const targetDate = parseISO(date);
 
+	// 日付の有効性をチェック
+	if (!isValid(targetDate)) {
+		console.warn("Invalid date string provided to isDateOccupied:", date);
+		return false;
+	}
+
 	return targetPeriods.some((period) => {
 		const startDate = parseISO(period.startDate);
 		const endDate = parseISO(period.endDate);
+
+		// 日付の有効性をチェック
+		if (!isValid(startDate) || !isValid(endDate)) {
+			console.warn("Invalid date string in period:", period);
+			return false;
+		}
+
 		return targetDate >= startDate && targetDate <= endDate;
 	});
 }
@@ -69,6 +93,12 @@ export function getOccupiedDates(
 	targetPeriods.forEach((period) => {
 		const startDate = parseISO(period.startDate);
 		const endDate = parseISO(period.endDate);
+
+		// 日付の有効性をチェック
+		if (!isValid(startDate) || !isValid(endDate)) {
+			console.warn("Invalid date string in period:", period);
+			return;
+		}
 
 		// 期間内の全ての日付を追加
 		const currentDate = new Date(startDate);

--- a/lib/utils/period-overlap.ts
+++ b/lib/utils/period-overlap.ts
@@ -1,6 +1,58 @@
 import type { Period } from "@/lib/types/gantt";
 
 /**
+ * 2つの日付範囲が重複しているかチェックする
+ */
+export function hasDateRangeOverlap(
+	range1: { startDate: string; endDate: string },
+	range2: { startDate: string; endDate: string },
+): boolean {
+	const start1 = new Date(range1.startDate);
+	const end1 = new Date(range1.endDate);
+	const start2 = new Date(range2.startDate);
+	const end2 = new Date(range2.endDate);
+
+	// 重複の条件: range1の開始日がrange2の終了日以前 かつ range1の終了日がrange2の開始日以降
+	return start1 <= end2 && end1 >= start2;
+}
+
+/**
+ * 指定された日付範囲が既存のPeriodと重複しているかチェックする
+ */
+export function hasOverlap(
+	newPeriod: { startDate: string; endDate: string },
+	existingPeriods: Period[],
+	excludeId?: string,
+): boolean {
+	const targetPeriods = excludeId
+		? existingPeriods.filter((p) => p.id !== excludeId)
+		: existingPeriods;
+
+	return targetPeriods.some((period) => hasDateRangeOverlap(newPeriod, period));
+}
+
+/**
+ * 指定された日付が既存のPeriodと重複しているかチェックする
+ */
+export function isDateOccupied(
+	date: string,
+	existingPeriods: Period[],
+	excludeId?: string,
+): boolean {
+	const targetPeriods = excludeId
+		? existingPeriods.filter((p) => p.id !== excludeId)
+		: existingPeriods;
+
+	const targetDate = new Date(date);
+
+	return targetPeriods.some((period) => {
+		const startDate = new Date(period.startDate);
+		const endDate = new Date(period.endDate);
+		return targetDate >= startDate && targetDate <= endDate;
+	});
+}
+
+/**
  * 既存のPeriodで占有されている日付のリストを取得する
  */
 export function getOccupiedDates(

--- a/lib/utils/period-overlap.ts
+++ b/lib/utils/period-overlap.ts
@@ -1,0 +1,29 @@
+import type { Period } from "@/lib/types/gantt";
+
+/**
+ * 既存のPeriodで占有されている日付のリストを取得する
+ */
+export function getOccupiedDates(
+	existingPeriods: Period[],
+	excludeId?: string,
+): string[] {
+	const targetPeriods = excludeId
+		? existingPeriods.filter((p) => p.id !== excludeId)
+		: existingPeriods;
+
+	const occupiedDates = new Set<string>();
+
+	targetPeriods.forEach((period) => {
+		const startDate = new Date(period.startDate);
+		const endDate = new Date(period.endDate);
+
+		// 期間内の全ての日付を追加
+		const currentDate = new Date(startDate);
+		while (currentDate <= endDate) {
+			occupiedDates.add(currentDate.toISOString().split("T")[0]);
+			currentDate.setDate(currentDate.getDate() + 1);
+		}
+	});
+
+	return Array.from(occupiedDates);
+}


### PR DESCRIPTION
## Issue
fixes #19

## 変更内容
- 重複チェック用ユーティリティ関数の追加 (`lib/utils/period-overlap.ts`)
- Calendar disabled dates機能の実装（AddPeriodModal、EditPeriodModal）
- TaskRowにPeriod重複制御機能を実装
- DnD時のトースト重複表示を修正
- 既存Period端のDnD編集時の重複チェック機能を実装

## 確認したこと
- [ ] 新規Period作成時に既存Periodと重複しないことを確認
- [ ] DnD操作時に重複チェックが正しく動作することを確認
- [ ] 既存Period編集時に重複チェックが正しく動作することを確認
- [ ] Calendar UIで重複する日付が無効化されることを確認
- [ ] エラーメッセージが適切に表示されることを確認
- [ ] 既存Period端のDnD編集時に適切な重複制御が行われることを確認